### PR TITLE
Exclude default language from i18n conversion tasks

### DIFF
--- a/build.js
+++ b/build.js
@@ -630,7 +630,7 @@ module.exports = function (gulpWrapper, ctx) {
             ], { cwd: ctx.baseDir })
             .pipe(pluginI18nTransform({
                 base: ctx.baseDir,
-                languages: i18n.supportedCultures,
+                languages: i18n.supportedCultures.filter(function(culture) { return culture !== i18n.startupCulture; }),
                 dest: "pot"
             }))
             .pipe(gulp.dest(ctx.baseDir));
@@ -647,7 +647,7 @@ module.exports = function (gulpWrapper, ctx) {
             ], { cwd: ctx.baseDir })
             .pipe(pluginI18nTransform({
                 base: ctx.baseDir,
-                languages: i18n.supportedCultures,
+                languages: i18n.supportedCultures.filter(function(culture) { return culture !== i18n.startupCulture; }),
                 dest: "ts"
             }))
             .pipe(gulp.dest(ctx.baseDir));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/dev-tasks",
-  "version": "5.1.6-3",
+  "version": "5.1.7-1",
   "description": "Gulp tasks and helpers for development",
   "main": "main.js",
   "dependencies": {


### PR DESCRIPTION
This PR excludes the default language from being processed in the i18n conversion tasks ts2po and po2ts.