### PR TITLE
Ignore metadata files in style/fonts

### DIFF
--- a/build.js
+++ b/build.js
@@ -494,6 +494,7 @@ module.exports = function (gulpWrapper, ctx) {
                 `${ctx.baseDir}src/**/*.ts`, 
                 `!${ctx.baseDir}src/**/*.d.ts`, 
                 `!${ctx.baseDir}src/**/i18n/*.ts`,
+                `!${ctx.baseDir}src/**/style/fonts/**/metadata.ts`,
             ...packageExclusionList.map((exclusion) => `!${ctx.baseDir}${exclusion}`)])
             .pipe(pluginTslint({
                 formatter: "stylish",


### PR DESCRIPTION
With this PR, the TSLink task ignores all metadata files in style/fonts, that are generated automatically (and can be minified)