### PR TITLE
Install in production for Apps

### DIFF
--- a/install/package.management.js
+++ b/install/package.management.js
@@ -146,6 +146,12 @@ module.exports = function (gulpWrapper, ctx) {
 			command = command + " --silent";
 		}
 
+		// Install production in webApp
+		// Don't need dev dependencies here, just keep it small
+		if (ctx.type === "webApp") {
+			command = command + " --production";
+		}
+
 		try {								
  			pluginExecute(command, { cwd: ctx.baseDir }, function(error, stdout, stderr) {
  				if (error instanceof Error) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/dev-tasks",
-  "version": "6.0.0-4",
+  "version": "6.0.0-5",
   "description": "Gulp tasks and helpers for development",
   "main": "main.js",
   "dependencies": {


### PR DESCRIPTION
With this PR, there is no need to install all dev dependencies in web app folder, that goes to production.