### PR TITLE
feat(dev-tasks): add tasks to deal with i18n in connectIoT packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/dev-tasks",
-  "version": "6.1.0-1",
+  "version": "6.1.0-2",
   "description": "Gulp tasks and helpers for development",
   "main": "main.js",
   "dependencies": {


### PR DESCRIPTION
Updated dev-tasks build to deal with i18n in ConnectIot tasks packages.
The original issue is that since these packages are not build in production, no startup culture were created (.default do not generated .en-US). 