### PR TITLE
Sanitize node exe to always be the calling one.

### DIFF
--- a/build.js
+++ b/build.js
@@ -249,7 +249,7 @@ module.exports = function (gulpWrapper, ctx) {
         promiseToResolve.then(function(tsConfigName) {
             tsConfigName = tsConfigName || null;
             //gulp.src('').pipe(pluginShell('tsc --outFile ' + ctx.packageName + ".js --project " + tsConfigName, { cwd: ctx.baseDir }))  // Un-comment when the compiler is able to exclude dependencies            
-            gulp.src('').pipe(pluginShell(process.execPath + ' --stack_size=4096 ' + typescriptCompilerPath + ' --outFile ' + ctx.packageName + ".js ", { cwd: ctx.baseDir })) // We could use gulp-typescript with src, but the declarations and sourceMaps are troublesome
+            gulp.src('').pipe(pluginShell('\"' + process.execPath + '\" --stack_size=4096 ' + typescriptCompilerPath + ' --outFile ' + ctx.packageName + ".js ", { cwd: ctx.baseDir })) // We could use gulp-typescript with src, but the declarations and sourceMaps are troublesome
                 .pipe(pluginCallback(function () {                                    
                     gulp.src(ctx.baseDir + ctx.packageName + ".js")  
 

--- a/build.js
+++ b/build.js
@@ -249,7 +249,7 @@ module.exports = function (gulpWrapper, ctx) {
         promiseToResolve.then(function(tsConfigName) {
             tsConfigName = tsConfigName || null;
             //gulp.src('').pipe(pluginShell('tsc --outFile ' + ctx.packageName + ".js --project " + tsConfigName, { cwd: ctx.baseDir }))  // Un-comment when the compiler is able to exclude dependencies            
-            gulp.src('').pipe(pluginShell('node --stack_size=4096 ' + typescriptCompilerPath + ' --outFile ' + ctx.packageName + ".js ", { cwd: ctx.baseDir })) // We could use gulp-typescript with src, but the declarations and sourceMaps are troublesome
+            gulp.src('').pipe(pluginShell(process.execPath + ' --stack_size=4096 ' + typescriptCompilerPath + ' --outFile ' + ctx.packageName + ".js ", { cwd: ctx.baseDir })) // We could use gulp-typescript with src, but the declarations and sourceMaps are troublesome
                 .pipe(pluginCallback(function () {                                    
                     gulp.src(ctx.baseDir + ctx.packageName + ".js")  
 
@@ -445,7 +445,7 @@ module.exports = function (gulpWrapper, ctx) {
     });
 
     gulp.task("__build-typescript", function (callback) {           
-        return gulp.src('').pipe(pluginShell('\"' + process.execPath + '\" --stack_size=4096 ' + typescriptCompilerPath, { cwd: ctx.baseDir }));                
+        return gulp.src('').pipe(pluginShell('\"' + process.execPath + '\" --stack_size=4096 ' + typescriptCompilerPath + (pluginYargs.listFiles ? " --listFiles" : ""), { cwd: ctx.baseDir }));
     });
 
     gulp.task("__build-less", function (callback) {

--- a/ci/publish.js
+++ b/ci/publish.js
@@ -37,7 +37,7 @@ module.exports = function (gulpWrapper, ctx) {
 
         return gulp
             .src("package.json", {cwd: ctx.baseDir})
-            .pipe(shell(`npm version ${targetVersion} --no-git-tag-version`, {cwd: ctx.baseDir, verbose: true}));
+            .pipe(shell(`${ctx.__cmfDevTasksConfig && ctx.__cmfDevTasksConfig.__npm ? ctx.__cmfDevTasksConfig.__npm : 'npm'} version ${targetVersion} --no-git-tag-version --scripts-prepend-node-path`, {cwd: ctx.baseDir, verbose: true}));
     });
 
     /**
@@ -50,7 +50,7 @@ module.exports = function (gulpWrapper, ctx) {
 
         return gulp
             .src("package.json", {cwd: ctx.baseDir})
-            .pipe(shell(`npm publish --tag=${tag} --git-tag-version=false`, {cwd: ctx.baseDir, verbose: true}));
+            .pipe(shell(`${ctx.__cmfDevTasksConfig && ctx.__cmfDevTasksConfig.__npm ? ctx.__cmfDevTasksConfig.__npm : 'npm'} publish --tag=${tag} --git-tag-version=false --scripts-prepend-node-path`, {cwd: ctx.baseDir, verbose: true}));
     });
 
 

--- a/ci/publish.js
+++ b/ci/publish.js
@@ -37,7 +37,7 @@ module.exports = function (gulpWrapper, ctx) {
 
         return gulp
             .src("package.json", {cwd: ctx.baseDir})
-            .pipe(shell(`${ctx.__cmfDevTasksConfig && ctx.__cmfDevTasksConfig.__npm ? ctx.__cmfDevTasksConfig.__npm : 'npm'} version ${targetVersion} --no-git-tag-version --scripts-prepend-node-path`, {cwd: ctx.baseDir, verbose: true}));
+            .pipe(shell(`${ctx.__cmfDevTasksConfig && ctx.__cmfDevTasksConfig.__npm ? ctx.__cmfDevTasksConfig.__npm : 'npm'} version ${targetVersion} --no-git-tag-version --scripts-prepend-node-path=true`, {cwd: ctx.baseDir, verbose: true}));
     });
 
     /**
@@ -50,7 +50,7 @@ module.exports = function (gulpWrapper, ctx) {
 
         return gulp
             .src("package.json", {cwd: ctx.baseDir})
-            .pipe(shell(`${ctx.__cmfDevTasksConfig && ctx.__cmfDevTasksConfig.__npm ? ctx.__cmfDevTasksConfig.__npm : 'npm'} publish --tag=${tag} --git-tag-version=false --scripts-prepend-node-path`, {cwd: ctx.baseDir, verbose: true}));
+            .pipe(shell(`${ctx.__cmfDevTasksConfig && ctx.__cmfDevTasksConfig.__npm ? ctx.__cmfDevTasksConfig.__npm : 'npm'} publish --tag=${tag} --git-tag-version=false --scripts-prepend-node-path=true`, {cwd: ctx.baseDir, verbose: true}));
     });
 
 

--- a/install/package.management.js
+++ b/install/package.management.js
@@ -53,7 +53,8 @@ module.exports = function (gulpWrapper, ctx) {
     * Installs all npm packages (public and private)
     */ 
     gulp.task('__npmInstall',  function(callback) {
-		var command = "npm install";
+		const npm = ctx.__cmfDevTasksConfig && ctx.__cmfDevTasksConfig.__npm ? ctx.__cmfDevTasksConfig.__npm : "npm";
+		var command = `${npm} ${pluginYargs.ci ? 'ci' : 'install'} --scripts-prepend-node-path`;
 
 		if (!ctx.__verbose) {
 			command = command + " --silent";
@@ -77,7 +78,7 @@ module.exports = function (gulpWrapper, ctx) {
      */ 
     gulp.task('__dedupeLibs',  function(callback) {	
 		try {								
- 			pluginExecute('npm dedupe', { cwd: ctx.baseDir }, function(error, stdout, stderr) {
+ 			pluginExecute(`${ctx.__cmfDevTasksConfig && ctx.__cmfDevTasksConfig.__npm ? ctx.__cmfDevTasksConfig.__npm : "npm"} dedupe --scripts-prepend-node-path`, { cwd: ctx.baseDir }, function(error, stdout, stderr) {
  				if (error instanceof Error) {
  					console.error(stderr);
  				}

--- a/install/package.management.js
+++ b/install/package.management.js
@@ -54,7 +54,7 @@ module.exports = function (gulpWrapper, ctx) {
     */ 
     gulp.task('__npmInstall',  function(callback) {
 		const npm = ctx.__cmfDevTasksConfig && ctx.__cmfDevTasksConfig.__npm ? ctx.__cmfDevTasksConfig.__npm : "npm";
-		var command = `${npm} ${pluginYargs.ci ? 'ci' : 'install'} --scripts-prepend-node-path`;
+		var command = `${npm} ${pluginYargs.ci ? 'ci' : 'install'} --scripts-prepend-node-path=true`;
 
 		if (!ctx.__verbose) {
 			command = command + " --silent";

--- a/install/package.management.js
+++ b/install/package.management.js
@@ -78,7 +78,7 @@ module.exports = function (gulpWrapper, ctx) {
      */ 
     gulp.task('__dedupeLibs',  function(callback) {	
 		try {								
- 			pluginExecute(`${ctx.__cmfDevTasksConfig && ctx.__cmfDevTasksConfig.__npm ? ctx.__cmfDevTasksConfig.__npm : "npm"} dedupe --scripts-prepend-node-path`, { cwd: ctx.baseDir }, function(error, stdout, stderr) {
+ 			pluginExecute(`${ctx.__cmfDevTasksConfig && ctx.__cmfDevTasksConfig.__npm ? ctx.__cmfDevTasksConfig.__npm : "npm"} dedupe --scripts-prepend-node-path=true`, { cwd: ctx.baseDir }, function(error, stdout, stderr) {
  				if (error instanceof Error) {
  					console.error(stderr);
  				}

--- a/main.js
+++ b/main.js
@@ -42,10 +42,18 @@ module.exports = function (gulp, ctx) {
         }
     });
 
+    const cmfDevTasksConfig = require(path.join(ctx.__repositoryRoot, "./.dev-tasks.json"));
+    ctx.__cmfDevTasksConfig = cmfDevTasksConfig;
+    Object.defineProperty(cmfDevTasksConfig, "__npm", {
+        configurable: true,
+        enumerable: true,
+        get: function(){
+            return cmfDevTasksConfig.npm ? path.resolve(path.join(ctx.__repositoryRoot, cmfDevTasksConfig.npm)) : null;
+        }
+    });
+
     if (!ctx.packagePrefix) {
-        var cmfDevTasksConfig;
         try {
-            cmfDevTasksConfig = require('../../../.dev-tasks.json');
             ctx.packagePrefix = cmfDevTasksConfig.packagePrefix;
         } catch (error) {
             pluginUtil.log(pluginUtil.colors.yellow("Unable to find '.dev-tasks'. Continuing..."));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/dev-tasks",
-  "version": "5.1.12-2",
+  "version": "5.1.15-0",
   "description": "Gulp tasks and helpers for development",
   "main": "main.js",
   "dependencies": {

--- a/root.main.js
+++ b/root.main.js
@@ -68,7 +68,7 @@ module.exports = {
         projects.forEach(function (project) {
             actions.forEach(function (action) {
                 operations.push({
-                    command: "node",
+                    command: process.execPath,
                     arguments: [path.join(__dirname, "../", "gulp", "bin", "gulp.js"), action].concat(args),
                     cwd: path.join(baseDir, project)
                 });

--- a/root.main.js
+++ b/root.main.js
@@ -68,7 +68,7 @@ module.exports = {
         projects.forEach(function (project) {
             actions.forEach(function (action) {
                 operations.push({
-                    command: process.execPath,
+                    command: '\"' + process.execPath + '\"',
                     arguments: [path.join(__dirname, "../", "gulp", "bin", "gulp.js"), action].concat(args),
                     cwd: path.join(baseDir, project)
                 });

--- a/utils.js
+++ b/utils.js
@@ -125,7 +125,7 @@ module.exports = {
         * 
         * @param function(boolean) callback Callback function
         */
-        hasAdministrationPrivileges: function (callback) {
+        hasAdministrationPriviledges: function (callback) {
             pluginExecute('net session', function (result, stdout, stderr) {
                 callback(result === null || result.code === 0);
             });

--- a/utils.js
+++ b/utils.js
@@ -121,11 +121,11 @@ module.exports = {
     cmd:
     {
         /**
-        * Check if gulp is running with Administration priviledges
+        * Check if gulp is running with Administration privileges
         * 
         * @param function(boolean) callback Callback function
         */
-        hasAdministrationPriviledges: function (callback) {
+        hasAdministrationPrivileges: function (callback) {
             pluginExecute('net session', function (result, stdout, stderr) {
                 callback(result === null || result.code === 0);
             });

--- a/web.main.js
+++ b/web.main.js
@@ -43,7 +43,7 @@ module.exports = function (gulpWrapper, ctx) {
      * Compile typescript files
      */
     gulp.task('build', function (cb) {
-        return gulp.src('').pipe(pluginShell("node " + typescriptCompilerPath, { cwd: ctx.baseDir }));
+        return gulp.src('').pipe(pluginShell(process.execPath + " " + typescriptCompilerPath, { cwd: ctx.baseDir }));
     });
 
     gulp.task('deploy', function(cb){

--- a/web.main.js
+++ b/web.main.js
@@ -43,7 +43,7 @@ module.exports = function (gulpWrapper, ctx) {
      * Compile typescript files
      */
     gulp.task('build', function (cb) {
-        return gulp.src('').pipe(pluginShell(process.execPath + " " + typescriptCompilerPath, { cwd: ctx.baseDir }));
+        return gulp.src('').pipe(pluginShell('\"' + process.execPath + '\" ' + typescriptCompilerPath, { cwd: ctx.baseDir }));
     });
 
     gulp.task('deploy', function(cb){


### PR DESCRIPTION
Sanitize npm to default to system only when not in .dev-tasks.
Clean-up and add groundwork for ci command.