### PR TITLE
lock less version to ~3.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "typescript": "3.2.4",
     "uuid": "~3.3.2",
     "yargs": "~12.0.5",
-    "tslint-no-circular-imports": "^0.7.0"
+    "tslint-no-circular-imports": "^0.7.0",
+    "less": "~3.9.0"
   },
   "devDependencies": {},
   "scripts": {},


### PR DESCRIPTION
"Less" dependency was updated causing "dependencies/cmf.style/src/main.less" to stop compiling successfully. This is a temporary fix.