### PR TITLE
Changes to run deploy and deploy-setup in Linux

### DIFF
--- a/deploy/web.deploy.exclude.txt
+++ b/deploy/web.deploy.exclude.txt
@@ -1,6 +1,6 @@
-node_modules\**\node_modules
-test\**
-**\test
+node_modules/**/node_modules
+test/**
+**/test
 tsconfig.json
 obj
 karma.conf.js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/dev-tasks",
-  "version": "8.0.0-9",
+  "version": "8.0.0-10",
   "description": "Gulp tasks and helpers for development",
   "main": "main.js",
   "dependencies": {

--- a/web.main.js
+++ b/web.main.js
@@ -236,7 +236,7 @@ module.exports = function (gulpWrapper, ctx) {
         var includePath = path.join(__dirname, "deploy", "web.deploy.include.txt");
         var excludePath = path.join(__dirname, "deploy", "web.deploy.exclude.txt");
 
-        var result = gulp
+        return  gulp
             .src('')
             .pipe(pluginShell(
                 "\"" + zipProgram + "\" a "
@@ -245,7 +245,6 @@ module.exports = function (gulpWrapper, ctx) {
                 ' -xr@"' + excludePath + '"' +
                 linksFlag
                 , { cwd: ctx.baseDir }));
-        return result;
     });
 
     /**

--- a/web.main.js
+++ b/web.main.js
@@ -207,7 +207,7 @@ module.exports = function (gulpWrapper, ctx) {
             .src('')
             .pipe(pluginShell("\"" + zipProgram + "\" a "
                 + tempFileName +
-                ' -x!node_modules\\**\\node_modules' +
+                ' -x!node_modules/**/node_modules' +
                 ' -ir@"' + includePath + '"' +
                 ' -xr@"' + excludePath + '"' + 
                 linksFlag, { cwd: ctx.baseDir }))


### PR DESCRIPTION
This PR will allow users to run **gulp deploy** and **gulp deploy-setup** in Linux.

Changes were made in making paths platform independent and the usage of 7zip util.

For now, and to maintain behaviour, we use the p7zip package, a port of 7zip to Linux. However the package has not been updated since version 16.04 (unlike its Windows counterpart which is currently in version 19.00, which means we should probably use an alternative like tar or zip.
Other alternative could be to use something like [gulp-zip](https://www.npmjs.com/package/gulp-zip)