### PR TITLE
Fix ModuleName as a Number Issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/dev-tasks",
-  "version": "8.0.0-10",
+  "version": "8.0.0-11",
   "description": "Gulp tasks and helpers for development",
   "main": "main.js",
   "dependencies": {

--- a/web.main.js
+++ b/web.main.js
@@ -178,9 +178,13 @@ module.exports = function (gulpWrapper, ctx) {
 
     gulp.task('deploy', function (cb) {
         var deployPath = pluginYargs.path ? pluginYargs.path : process.env.BUILD_ARTIFACTSTAGINGDIRECTORY;
+        var moduleName = pluginYargs.moduleName;
 
-        if (pluginYargs.moduleName) {
-            deployPath = path.join(deployPath, pluginYargs.moduleName);
+        if (typeof deployPath !== 'string') { deployPath = deployPath.toString(); }
+        if (typeof moduleName !== 'string') { moduleName = moduleName.toString(); }
+
+        if (moduleName) {
+            deployPath = path.join(deployPath, moduleName);
         }
 
         var tempFileName = ctx.baseDir + uuid.v4() + ".zip";

--- a/web.main.js
+++ b/web.main.js
@@ -226,9 +226,13 @@ module.exports = function (gulpWrapper, ctx) {
     gulp.task('deploy-setup', function (cb) {
         var deployPath = pluginYargs.path ? pluginYargs.path : process.env.BUILD_ARTIFACTSTAGINGDIRECTORY;
         var tokensFile = pluginYargs.appFileName ? pluginYargs.appFileName : "config.setup.json";
+        var moduleName = pluginYargs.moduleName;
+        
+        if (typeof deployPath !== 'string') { deployPath = deployPath.toString(); }
+        if (typeof moduleName !== 'string') { moduleName = moduleName.toString(); }
 
-        if (pluginYargs.moduleName) {
-            deployPath += "\\" + pluginYargs.moduleName + ".zip";
+        if (moduleName) {
+            deployPath = path.join(deployPath, moduleName + ".zip");
         }
 
         // Change name

--- a/web.main.js
+++ b/web.main.js
@@ -179,12 +179,9 @@ module.exports = function (gulpWrapper, ctx) {
     gulp.task('deploy', function (cb) {
         var deployPath = pluginYargs.path ? pluginYargs.path : process.env.BUILD_ARTIFACTSTAGINGDIRECTORY;
         var moduleName = pluginYargs.moduleName;
-
-        if (typeof deployPath !== 'string') { deployPath = deployPath.toString(); }
-        if (typeof moduleName !== 'string') { moduleName = moduleName.toString(); }
-
+        
         if (moduleName) {
-            deployPath = path.join(deployPath, moduleName);
+            deployPath += path.sep + moduleName;
         }
 
         var tempFileName = ctx.baseDir + uuid.v4() + ".zip";
@@ -197,7 +194,7 @@ module.exports = function (gulpWrapper, ctx) {
         if (!fs.existsSync(deployPath)) {
             fs.mkdirSync(deployPath);
         } else {
-            var pathToDelete = path.join(deployPath, "**");
+            var pathToDelete = deployPath + path.sep +  "**";
             console.log("Deleting path " + pathToDelete);
             pluginDel.sync([pathToDelete, "!" + deployPath], { force: true });
         }
@@ -228,11 +225,8 @@ module.exports = function (gulpWrapper, ctx) {
         var tokensFile = pluginYargs.appFileName ? pluginYargs.appFileName : "config.setup.json";
         var moduleName = pluginYargs.moduleName;
         
-        if (typeof deployPath !== 'string') { deployPath = deployPath.toString(); }
-        if (typeof moduleName !== 'string') { moduleName = moduleName.toString(); }
-
         if (moduleName) {
-            deployPath = path.join(deployPath, moduleName + ".zip");
+            deployPath += path.sep +  moduleName + ".zip";
         }
 
         // Change name


### PR DESCRIPTION
This PR fixes an issue happening when a moduleName is a number. This is because path.join() internal validation doesn't allow an argument to be a number.