### PR TITLE
Node 12 brought some issues related with elasticlurnr indexing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/dev-tasks",
-  "version": "8.0.0-11",
+  "version": "8.0.0-12",
   "description": "Gulp tasks and helpers for development",
   "main": "main.js",
   "dependencies": {
@@ -10,7 +10,7 @@
     "clean-css": "~4.2.1",
     "codelyzer": "^4.5.0",
     "del": "~3.0.0",
-    "elasticlunr": "^0.9.5",
+    "lunr": "^2.3.8",
     "find-node-modules": "^2.0.0",
     "fs-extra": "~7.0.1",
     "graceful-fs": "4.2.2",


### PR DESCRIPTION
Node 12 brought some issues related
with elasticlunr indexing proccessment. 
The index json generated by elasticlurn,
causes maximum call stack size exceeded error on JSON.stringify.
To solve this problem, the search library was changed to lurn.js