### PR TITLE
Display npm install error output by default.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/dev-tasks",
-  "version": "8.0.4-1",
+  "version": "8.0.4-2",
   "description": "Gulp tasks and helpers for development",
   "main": "main.js",
   "dependencies": {


### PR DESCRIPTION
Add loglevel switch to allow other verbosity options. Loglevel silent provides only build-breaking info.