### PR TITLE
feat(): Add typescriptPath option for compilation

### DIFF
--- a/build.js
+++ b/build.js
@@ -62,7 +62,7 @@ module.exports = function (gulpWrapper, ctx) {
 	
     var rootFolderName = ctx.__repositoryRoot.replace(/\\/g, '/').split('/').pop();
 
-    var typescriptCompilerPath = utils.dependencies.lookupNodeModule("typescript") + "/bin/tsc";
+    var typescriptCompilerPath = (ctx.typescriptPath || utils.dependencies.lookupNodeModule("typescript")) + "/bin/tsc";
     var tslintPath = utils.dependencies.lookupNodeModule("tslint") + "/bin/tslint";
 
     var includePackagePrefix = { match: new RegExp("\"src\/[^\"]", 'g'), replacement: function (match) { return match.slice(0, 1) + ctx.packageName + "/" + match.slice(1); } };    

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/dev-tasks",
-  "version": "8.1.0-0",
+  "version": "8.2.0-0",
   "description": "Gulp tasks and helpers for development",
   "main": "main.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/dev-tasks",
-  "version": "8.1.0",
+  "version": "8.1.0-0",
   "description": "Gulp tasks and helpers for development",
   "main": "main.js",
   "dependencies": {


### PR DESCRIPTION
This is a simple PR that adds an option for an alternative typescript path to be passed in the context.