### PR TITLE
[83x] Add brotli compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Can only be used in conjunction with ```--production```. This option uses node.j
 When this option is active it will, by default, compress 200 files concurrently (see ```--parallel-brotli``` option).
 
 ##### --parallel-brotli <number_of_parallel_files>
-Is only taken in consideration when the ```--brotli``` option can be used. Determines the number of concurrent files being compressed at a time. 
+This option is only taken in consideration when the ```--brotli``` option is used. Determines the number of concurrent files being compressed at a time. 
 
 It defaults to batches of 200 files. The batches are sequential and within each batch the files are compressed concurrently.
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,18 @@ Should be used in conjunction with ```--production```. On top of the packages, i
 
 This flag should be used if the package is meant to be redistributed and extended by others.
 
+##### --brotli
+Should be used in conjunction with ```--production```. This option uses node.js' brotli implementation to compress both the `bundles` and `node_modules` directories present in the output ```/apps/``` directory and creates the corresponding `.br` files.
+
+This is active by default compressing 200 files concurrently (see ```--parallel-brotli``` option).
+
+Use ```--no-brotli``` to disable this option.
+
+##### --parallel-brotli <number_of_parallel_files>
+Is only taken in consideration when the ```--brotli``` option can be used. Determines the number of concurrent files being compressed at a time. 
+
+It defaults to batches of 200 files. The batches are sequential and within each batch the files are compressed concurrently.
+
 ## App
 
 ### Start

--- a/README.md
+++ b/README.md
@@ -97,11 +97,9 @@ Should be used in conjunction with ```--production```. On top of the packages, i
 This flag should be used if the package is meant to be redistributed and extended by others.
 
 ##### --brotli
-Should be used in conjunction with ```--production```. This option uses node.js' brotli implementation to compress both the `bundles` and `node_modules` directories present in the output ```/apps/``` directory and creates the corresponding `.br` files.
+Can only be used in conjunction with ```--production```. This option uses node.js' brotli implementation to compress both the `bundles` and `node_modules` directories present in the output ```/apps/``` directory and creates the corresponding `.br` files.
 
-This is active by default compressing 200 files concurrently (see ```--parallel-brotli``` option).
-
-Use ```--no-brotli``` to disable this option.
+When this option is active it will, by default, compress 200 files concurrently (see ```--parallel-brotli``` option).
 
 ##### --parallel-brotli <number_of_parallel_files>
 Is only taken in consideration when the ```--brotli``` option can be used. Determines the number of concurrent files being compressed at a time. 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/dev-tasks",
-  "version": "8.3.0",
+  "version": "8.3.0-1",
   "description": "Gulp tasks and helpers for development",
   "main": "main.js",
   "dependencies": {

--- a/web.main.js
+++ b/web.main.js
@@ -245,7 +245,7 @@ module.exports = function (gulpWrapper, ctx) {
                 if (pluginYargs.brotli === undefined || pluginYargs.brotli === true)
                     tasks = tasks.concat([`_brotli`]);
             }
-            else if (pluginYargs.brotli === undefined || pluginYargs.brotli === true || pluginYargs.parallelBrotli) {
+            else if (pluginYargs.brotli === true || pluginYargs.parallelBrotli) {
                 pluginUtil.log(pluginUtil.colors.red('Brotli compression is only allowed when building in production mode (use --production). Continuing without compression...'));
             }
         }

--- a/web.main.js
+++ b/web.main.js
@@ -240,9 +240,8 @@ module.exports = function (gulpWrapper, ctx) {
         var tasks = ['_build'];
         if (ctx.isBundleBuilderOn && ctx.isBundleBuilderOn === true) {
             tasks = tasks.concat(['_bundle-app']);
-            // By default, compresses files using brotli
             if (pluginYargs.production) {
-                if (pluginYargs.brotli === undefined || pluginYargs.brotli === true)
+                if (pluginYargs.brotli === true)
                     tasks = tasks.concat([`_brotli`]);
             }
             else if (pluginYargs.brotli === true || pluginYargs.parallelBrotli) {

--- a/web.main.js
+++ b/web.main.js
@@ -14,8 +14,13 @@ var minify = require('gulp-minify');
 var cleanCss = require('gulp-clean-css');
 const path = require('path');
 var pluginUtil = require('gulp-util');
+var zlib = require('zlib');
+
+// Default batch size of parallel files to compress
+const BROTLI_PARALLEL_FILES_DEFAULT = 200;
 
 module.exports = function (gulpWrapper, ctx) {
+
 
     var bundlePath = ctx.bundlePath ? ctx.bundlePath : "bundles";
 
@@ -225,6 +230,7 @@ module.exports = function (gulpWrapper, ctx) {
                 }
             });
         }
+        cb();
     });
 
     /**
@@ -234,6 +240,14 @@ module.exports = function (gulpWrapper, ctx) {
         var tasks = ['_build'];
         if (ctx.isBundleBuilderOn && ctx.isBundleBuilderOn === true) {
             tasks = tasks.concat(['_bundle-app']);
+            // By default, compresses files using brotli
+            if (pluginYargs.production) {
+                if (pluginYargs.brotli === undefined || pluginYargs.brotli === true)
+                    tasks = tasks.concat([`_brotli`]);
+            }
+            else if (pluginYargs.brotli === undefined || pluginYargs.brotli === true || pluginYargs.parallelBrotli) {
+                pluginUtil.log(pluginUtil.colors.red('Brotli compression is only allowed when building in production mode (use --production). Continuing without compression...'));
+            }
         }
         return pluginRunSequence(tasks, cb);
     });
@@ -242,6 +256,98 @@ module.exports = function (gulpWrapper, ctx) {
      */
     gulp.task('_build', function (cb) {
         return gulp.src('').pipe(pluginShell('\"' + process.execPath + '\" ' + typescriptCompilerPath, { cwd: ctx.baseDir }));
+    });
+
+    /**
+     * Brotli compress task
+     */
+
+    /**
+     * Recursive function to traverse file directories with a depth limit of symlink directories to traverse
+     * @param {string} dir - Directory to recursively traverse
+     * @param {Array.<RegExp>} includeRegex - Regex expressions to match files
+     * @param {Array.<RegExp>} excludeRegex - Regex expressions to exclude files
+     * @param {Number} symlinkMaxDepth - Maximum depth of symlink directories allowed to traverse (to avoid infinite loops)
+     * @param {Number} symlinkDepth - Current depth of symlink directories already traversed
+     * @returns {Array.<string>} - Array containing the path of the matched files
+     */
+    function getFiles(dir, includeRegex, excludeRegex, symlinkMaxDepth, symlinkDepth=0) {
+        const dirContents = fs.readdirSync(dir, { withFileTypes: true });
+        const files = dirContents.reduce((files, dirContent) => {
+            const res = path.resolve(dir, dirContent.name);
+            if (dirContent.isSymbolicLink()) {
+                if (symlinkDepth < symlinkMaxDepth) {
+                    return files.concat(getFiles(res, includeRegex, excludeRegex, symlinkMaxDepth, symlinkDepth + 1));
+                }
+            }
+            else {
+                if (dirContent.isDirectory()) {
+                    return files.concat(getFiles(res, includeRegex, excludeRegex, symlinkMaxDepth, symlinkDepth));
+                }
+                else {
+                    if (!excludeRegex.some((r) => r.test(res)) && includeRegex.some((r) => r.test(res))) {
+                        files.push(res);
+                    }
+                }
+            }
+            return files;
+        }, []);
+        return Array.prototype.concat(...files);
+    }
+
+    /**
+     * Uses brotli to compress the given file and saves it with ".br" in the same directory
+     * @param {string} filepath - Path to the file to compress
+     */
+    function compressFile(filepath) {
+        const fileContents = fs.readFileSync(filepath);
+        let compressedFile = zlib.brotliCompressSync(fileContents, {
+            params: {
+                [zlib.constants.BROTLI_PARAM_QUALITY]: zlib.constants.BROTLI_MAX_QUALITY,
+            }
+        });
+        fs.writeFileSync(filepath + '.br', compressedFile);
+    }
+
+    gulp.task('_brotli', function (cb) {
+        let excludes = ['.*-debug\.js$', 'gulpfile\.js', 'package\.json', 'npm-shrinkwrap\.json', 'npm.postinstall\.js', 'npm.preinstall\.js', '.*\.br$']
+        let includes = ['.*\.js$', '.*\.json$', '.*\.svg$', '.*\.css$', '.*\.xml$', '.*\.csv$', '.*\.txt$']
+        const excludeRegex = excludes.map((r) => new RegExp(r));
+        const includeRegex = includes.map((r) => new RegExp(r));
+        
+        let parallelBrotliFiles = BROTLI_PARALLEL_FILES_DEFAULT;
+        if (pluginYargs.parallelBrotli) {
+            if(pluginYargs.parallelBrotli === 0) {
+                pluginUtil.log(pluginUtil.colors.yellow(`Parallel brotli flag requires explicit number of concurrent compressing files!\nDefaulting to compress ${parallelBrotliFiles} files using brotli in parallel`));
+            } else {
+                parallelBrotliFiles = Number.isInteger(pluginYargs.parallelBrotli) ? pluginYargs.parallelBrotli : BROTLI_PARALLEL_FILES_DEFAULT;
+                pluginUtil.log(pluginUtil.colors.yellow(`Compressing ${parallelBrotliFiles} files using brotli in parallel`));
+            }
+        }        
+
+        let bundlesFiles = getFiles(path.join(ctx.baseDir, 'bundles'), includeRegex, excludeRegex, 1);
+        let nodeFiles = getFiles(path.join(ctx.baseDir, 'node_modules'), includeRegex, excludeRegex, 1);
+        
+        let compressedFilesCount = 0;
+        let parallelCompressFiles = (filepaths) => {
+            // compress a batch of <parallelBrotliFiles> files in parallel (batches are sequential)
+            Promise.all(filepaths.splice(0, parallelBrotliFiles).map(filepath => compressFile(filepath)))
+                .then((_) => {
+                    // If there are more files to compress, make recursive call
+                    // Otherwise, call callback to indicate task completion
+                    if (filepaths.length > 0) {
+                        compressedFilesCount += parallelBrotliFiles;
+                        // Print a message every 10 completed batches
+                        if ((compressedFilesCount / parallelBrotliFiles) % 10 === 0)
+                            pluginUtil.log(`Brotli compress: ${filepaths.length} files remaining...`);
+                        return parallelCompressFiles(filepaths);
+                    }
+                    else
+                        cb();
+                });
+        }
+        
+        parallelCompressFiles(bundlesFiles.concat(nodeFiles));
     });
 
     gulp.task('deploy', function (cb) {


### PR DESCRIPTION
Adds, by default, the brotli compression task when using ```build --production```. This option compresses the ```bundles``` and ```node_modules``` final folders to be delivered.
Documentation was updated with new options along with package version.