### PR TITLE
[83x-cherry-pick] Add brotli compression on master

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,16 @@ Should be used in conjunction with ```--production```. On top of the packages, i
 
 This flag should be used if the package is meant to be redistributed and extended by others.
 
+##### --brotli
+Can only be used in conjunction with ```--production```. This option uses node.js' brotli implementation to compress both the `bundles` and `node_modules` directories present in the output ```/apps/``` directory and creates the corresponding `.br` files.
+
+When this option is active it will, by default, compress 200 files concurrently (see ```--parallel-brotli``` option).
+
+##### --parallel-brotli <number_of_parallel_files>
+This option is only taken in consideration when the ```--brotli``` option is used. Determines the number of concurrent files being compressed at a time. 
+
+It defaults to batches of 200 files. The batches are sequential and within each batch the files are compressed concurrently.
+
 ## App
 
 ### Start

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/dev-tasks",
-  "version": "9.0.0-2",
+  "version": "9.0.0-3",
   "description": "Gulp tasks and helpers for development",
   "main": "main.js",
   "dependencies": {


### PR DESCRIPTION
Adds, by default, the brotli compression task when using build ```--production```. This option compresses the ```bundles``` and ```node_modules``` final folders to be delivered.
Documentation was updated with new options along with package version.