### PR TITLE
During the build process we had a problem with files without an extension

### DIFF
--- a/web.main.js
+++ b/web.main.js
@@ -293,7 +293,7 @@ module.exports = function (gulpWrapper, ctx) {
      * @returns {Array.<string>} - Array containing the paths of the matched files. Empty array if path does not exist or no files are matched.
      */
     function getFiles(dir, includeRegex, excludeRegex, symlinkMaxDepth, symlinkDepth=0) {
-        if (!fs.existsSync(dir))
+        if (!fs.existsSync(dir) || !fs.lstatSync(dir).isDirectory())
             return [];
         const dirContents = fs.readdirSync(dir, { withFileTypes: true });
         const files = dirContents.reduce((files, dirContent) => {


### PR DESCRIPTION
During the build process (using cmf build or gulp build) we had a problem with files without an extension that for some reason were being used as directories. This misidentification would cause a failure while calling the fs.readdirSync method, this failure would stop the building process.