### PR TITLE
fix(web main): avoid exceeding the call stack size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/dev-tasks",
-  "version": "9.0.4-1",
+  "version": "9.1.0-0",
   "description": "Gulp tasks and helpers for development",
   "main": "main.js",
   "dependencies": {

--- a/web.main.js
+++ b/web.main.js
@@ -315,7 +315,7 @@ module.exports = function (gulpWrapper, ctx) {
             }
             return files;
         }, []);
-        return Array.prototype.concat(...files);
+        return files.reduce((acc, val) => acc.concat(val), []);
     }
 
     /**

--- a/web.main.js
+++ b/web.main.js
@@ -349,7 +349,9 @@ module.exports = function (gulpWrapper, ctx) {
         }        
 
         let bundlesFiles = getFiles(path.join(ctx.baseDir, 'bundles'), includeRegex, excludeRegex, 1);
+        pluginUtil.log(`Number files in bundles folder: ${bundlesFiles.length}`);
         let nodeFiles = getFiles(path.join(ctx.baseDir, 'node_modules'), includeRegex, excludeRegex, 1);
+        pluginUtil.log(`Number files in node_modules folder: ${nodeFiles.length}`);
         
         let compressedFilesCount = 0;
         let parallelCompressFiles = (filepaths) => {


### PR DESCRIPTION
Array.prototype.concat method can lead to exceeding the call stack size when used with a very large number